### PR TITLE
Update category hotfix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -759,8 +759,20 @@ decl_module! {
             // Get path from parent to root of category tree.
             let category_tree_path = Self::ensure_valid_category_and_build_category_tree_path(category_id)?;
 
-            // Make sure we can actually mutate this category
-            Self::ensure_can_mutate_in_path_leaf(&category_tree_path)?;
+            // When we are dealing witha non-root category, we
+            // must ensure mutability of our category by traversing to
+            // root.
+            if category_tree_path.len() > 1  {
+
+                // We must skip checking category itself.
+                // NB: This is kind of hacky way to avoid last element, 
+                // something clearn can be done later.
+                let mut path_to_check = category_tree_path.clone();
+                path_to_check.remove(0);
+
+                Self::ensure_can_mutate_in_path_leaf(&path_to_check)?;
+            } 
+
             // If the category itself is already deleted, then this
             // update *most* simultanously do an undelete, otherwise it is blocked,
             // as we do not permit unarchiving a deleted category. Doing 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -759,7 +759,7 @@ decl_module! {
             // Get path from parent to root of category tree.
             let category_tree_path = Self::ensure_valid_category_and_build_category_tree_path(category_id)?;
 
-            // When we are dealing witha non-root category, we
+            // When we are dealing with a non-root category, we
             // must ensure mutability of our category by traversing to
             // root.
             if category_tree_path.len() > 1  {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -774,7 +774,7 @@ decl_module! {
             } 
 
             // If the category itself is already deleted, then this
-            // update *most* simultanously do an undelete, otherwise it is blocked,
+            // update *must* simultaneously do an undelete, otherwise it is blocked,
             // as we do not permit unarchiving a deleted category. Doing 
             // a simultanous undelete and unarchive is accepted.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,6 +292,7 @@ const ERROR_ACCOUNT_DOES_NOT_MATCH_POST_AUTHOR: &str = "Account does not match p
 const ERROR_POST_MODERATED: &str = "Post is moderated.";
 const ERROR_POST_MODERATION_RATIONALE_TOO_SHORT: &str = "Post moderation rationale too short.";
 const ERROR_POST_MODERATION_RATIONALE_TOO_LONG: &str = "Post moderation rationale too long.";
+const ERROR_CATEGORY_NOT_BEING_UPDATED: &str = "Category not being updated.";
 
 //use srml_support::storage::*;
 
@@ -747,6 +748,12 @@ decl_module! {
 
             // Not signed by forum SUDO
             Self::ensure_is_forum_sudo(&who)?;
+
+            // Make sure something is actually being changed
+            ensure!(
+                new_archival_status.is_some() || new_deletion_status.is_some(),
+                ERROR_CATEGORY_NOT_BEING_UPDATED
+            );
 
             // Get path from parent to root of category tree.
             let category_tree_path = Self::ensure_valid_category_and_build_category_tree_path(category_id)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -781,7 +781,7 @@ decl_module! {
             let category = <CategoryById<T>>::get(category_id);
 
             ensure!(
-                !category.deleted || (new_deletion_status.is_some() && new_deletion_status.unwrap()),
+                !category.deleted || (new_deletion_status == Some(false)),
                 ERROR_CATEGORY_CANNOT_BE_UNARCHIVED_WHEN_DELETED
             );
 

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -206,6 +206,46 @@ pub fn default_genesis_config() -> GenesisConfig<Runtime> {
     }
 }
 
+pub type RuntimeMap<K,V> = std::vec::Vec<(K, V)>;
+pub type RuntimeCategory = Category< <Runtime as system::Trait>::BlockNumber, <Runtime as timestamp::Trait>::Moment, <Runtime as system::Trait>::AccountId>;
+pub type RuntimeThread = Thread< <Runtime as system::Trait>::BlockNumber, <Runtime as timestamp::Trait>::Moment, <Runtime as system::Trait>::AccountId>;
+pub type RuntimePost = Post< <Runtime as system::Trait>::BlockNumber, <Runtime as timestamp::Trait>::Moment, <Runtime as system::Trait>::AccountId>;
+pub type RuntimeBlockchainTimestamp = BlockchainTimestamp<<Runtime as system::Trait>::BlockNumber, <Runtime as timestamp::Trait>::Moment>;
+
+pub fn genesis_config(
+    category_by_id: &RuntimeMap<CategoryId, RuntimeCategory>,
+    next_category_id: u64,
+    thread_by_id: &RuntimeMap<ThreadId, RuntimeThread>,
+    next_thread_id: u64,
+    post_by_id: &RuntimeMap<PostId, RuntimePost>,
+    next_post_id: u64,
+    forum_sudo: <Runtime as system::Trait>::AccountId,
+    category_title_constraint: &InputValidationLengthConstraint,
+    category_description_constraint: &InputValidationLengthConstraint,
+    thread_title_constraint: &InputValidationLengthConstraint,
+    post_text_constraint: &InputValidationLengthConstraint,
+    thread_moderation_rationale_constraint: &InputValidationLengthConstraint,
+    post_moderation_rationale_constraint: &InputValidationLengthConstraint
+    ) 
+    -> GenesisConfig<Runtime> {
+
+    GenesisConfig::<Runtime> {
+        category_by_id: category_by_id.clone(),
+        next_category_id: next_category_id,
+        thread_by_id: thread_by_id.clone(),
+        next_thread_id: next_thread_id,
+        post_by_id: post_by_id.clone(),
+        next_post_id: next_post_id,
+        forum_sudo: forum_sudo,
+        category_title_constraint: category_title_constraint.clone(),
+        category_description_constraint: category_description_constraint.clone(),
+        thread_title_constraint: thread_title_constraint.clone(),
+        post_text_constraint: post_text_constraint.clone(),
+        thread_moderation_rationale_constraint: thread_moderation_rationale_constraint.clone(),
+        post_moderation_rationale_constraint: post_moderation_rationale_constraint.clone()
+    }
+}
+
 // MockForumUserRegistry
 pub fn default_mock_forum_user_registry_genesis_config() -> registry::GenesisConfig<Runtime> {
 

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -121,6 +121,11 @@ pub enum OriginType {
     Root
 }
 
+/*
+ * These test fixtures can be heavily refactored to avoid repotition, needs macros, and event
+ * assertions are also missing.
+ */ 
+
 pub struct CreateCategoryFixture {
     pub origin: OriginType,
     pub parent: Option<CategoryId>,
@@ -143,6 +148,34 @@ impl CreateCategoryFixture {
                 self.parent,
                 self.title.clone(),
                 self.description.clone()
+            ),
+            self.result
+        )
+    }
+}
+
+pub struct UpdateCategoryFixture {
+    pub origin: OriginType,
+    pub category_id: CategoryId,
+    pub new_archival_status: Option<bool>,
+    pub new_deletion_status: Option<bool>,
+    pub result: dispatch::Result
+}
+
+impl UpdateCategoryFixture {
+
+    pub fn call_and_assert(&self) {
+
+        assert_eq!(
+            TestForumModule::update_category(
+                match self.origin {
+                    OriginType::Signed(account_id) => Origin::signed(account_id),
+                    //OriginType::Inherent => Origin::inherent,
+                    OriginType::Root => system::RawOrigin::Root.into() //Origin::root
+                },
+                self.category_id,
+                self.new_archival_status.clone(),
+                self.new_deletion_status.clone()
             ),
             self.result
         )

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -257,9 +257,9 @@ pub fn default_mock_forum_user_registry_genesis_config() -> registry::GenesisCon
 // NB!:
 // Wanted to have payload: a: &GenesisConfig<Test>
 // but borrow checker made my life miserabl, so giving up for now.
-pub fn build_test_externalities() -> runtime_io::TestExternalities<Blake2Hasher> {
+pub fn build_test_externalities(config: GenesisConfig<Runtime>) -> runtime_io::TestExternalities<Blake2Hasher> {
 
-    let mut t = default_genesis_config()
+    let mut t = config
         .build_storage()
         .unwrap()
         .0;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -133,6 +133,98 @@ fn create_category_title_too_long() {
  * create_category_immutable_ancestor_category
  */
 
+
+
+#[test]
+fn update_category_undelete_and_unarchive() {
+
+    /*
+     * Create an initial state with two levels of categories, where
+     * leaf category is deleted, and then try to undelete.
+     */
+
+    let forum_sudo = 32;
+
+    let created_at = RuntimeBlockchainTimestamp {
+        block : 0,
+        time: 0
+    };
+
+    let category_by_id =  vec![
+
+        // A root category
+        (0, Category{
+            id: 0,
+            title: "New root".as_bytes().to_vec(),
+            description: "This is a new root category".as_bytes().to_vec(),
+            created_at : created_at.clone(),
+            deleted: false,
+            archived: false,
+            num_direct_subcategories: 1,
+            num_direct_unmoderated_threads: 0,
+            num_direct_moderated_threads: 0,
+            position_in_parent_category: None,
+            moderator_id: forum_sudo
+        }),
+
+        // A subcategory of the one above
+        (1, Category{
+            id: 1,
+            title: "New subcategory".as_bytes().to_vec(),
+            description: "This is a new subcategory to root category".as_bytes().to_vec(),
+            created_at : created_at.clone(),
+            deleted: true,
+            archived: false,
+            num_direct_subcategories: 0,
+            num_direct_unmoderated_threads: 0,
+            num_direct_moderated_threads: 0,
+            position_in_parent_category: Some(
+                ChildPositionInParentCategory {
+                    parent_id: 0,
+                    child_nr_in_parent_category: 1
+                }
+            ),
+            moderator_id: forum_sudo
+        }),
+    ];
+
+    // Set constraints to be sloppy, we don't care about enforcing them.
+    let sloppy_constraint = InputValidationLengthConstraint{
+        min: 0,
+        max_min_diff: 1000
+    };
+
+    let config = genesis_config( 
+        &category_by_id, // category_by_id
+        category_by_id.len() as u64, // next_category_id
+        &vec![], // thread_by_id
+        0, // next_thread_id
+        &vec![], // post_by_id
+        0, // next_post_id
+        forum_sudo, 
+        &sloppy_constraint,
+        &sloppy_constraint,
+        &sloppy_constraint,
+        &sloppy_constraint,
+        &sloppy_constraint,
+        &sloppy_constraint
+    );
+
+    with_externalities(&mut build_test_externalities(config), || {
+
+        UpdateCategoryFixture {
+            origin: OriginType::Signed(forum_sudo),
+            category_id: category_by_id[1].1.id,
+            new_archival_status: None, // same as before
+            new_deletion_status: Some(true), // delete
+            result: Ok(())
+        }
+        .call_and_assert();
+
+    });
+}
+
+
 /*
  * create_thread 
  * ==============================================================================

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -24,7 +24,10 @@ use srml_support::{assert_ok};
 
 #[test]
 fn set_forum_sudo_unset() {
-    with_externalities(&mut build_test_externalities(), || {
+
+    let config = default_genesis_config();
+
+    with_externalities(&mut build_test_externalities(config), || {
 
         // Ensure that forum sudo is default
         assert_eq!(TestForumModule::forum_sudo(), Some(33));
@@ -42,7 +45,10 @@ fn set_forum_sudo_unset() {
 
 #[test]
 fn set_forum_sudo_update() {
-    with_externalities(&mut build_test_externalities(), || {
+
+    let config = default_genesis_config();
+
+    with_externalities(&mut build_test_externalities(config), || {
 
         // Ensure that forum sudo is default
         assert_eq!(TestForumModule::forum_sudo(), Some(default_genesis_config().forum_sudo));
@@ -75,7 +81,10 @@ fn set_forum_sudo_update() {
 
 #[test]
 fn create_category_successfully() {
-    with_externalities(&mut build_test_externalities(), || {
+
+    let config = default_genesis_config();
+
+    with_externalities(&mut build_test_externalities(config), || {
 
         CreateCategoryFixture {
             origin: OriginType::Signed(default_genesis_config().forum_sudo),
@@ -92,7 +101,10 @@ fn create_category_successfully() {
 
 #[test]
 fn create_category_title_too_long() {
-    with_externalities(&mut build_test_externalities(), || {
+
+    let config = default_genesis_config();
+
+    with_externalities(&mut build_test_externalities(config), || {
 
         let genesis_config = default_genesis_config();
 
@@ -134,7 +146,10 @@ fn create_category_title_too_long() {
 
 #[test]
 fn create_thread_not_forum_member() {
-    with_externalities(&mut build_test_externalities(), || {
+
+    let config = default_genesis_config();
+
+    with_externalities(&mut build_test_externalities(config), || {
 
         let new_member = registry::Member {
             id : 113


### PR DESCRIPTION
Fixes three separate bugs, and also introduces test for the one of them, along with new testing utilities for creating arbitrary genesis configurations. The bugs were

1. Checking a category, not only its parents, for mutability. Addresses https://github.com/Joystream/substrate-forum-module/issues/24
2. Allowing unarchiving of a deleted category.
3. Allowing updating to go through with blank updates, so `update_category(id, None, None)`