### PR TITLE
substrate v2 fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,48 +1,48 @@
 [package]
-name = "substrate-forum-module"
-version = "1.1.0"
-authors = ["Bedeho Mender <bedeho.mender@protonmail.com>"]
-edition = "2018"
+name = 'substrate-forum-module'
+version = '1.1.0'
+authors = ['Bedeho Mender <bedeho.mender@protonmail.com>']
+edition = '2018'
 
 [dependencies]
-hex-literal = "0.1.0"
-serde = { version = "1.0", optional = true }
-serde_derive = { version = "1.0", optional = true }
-rstd = { package = 'sr-std', default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}
-runtime-primitives = { package = 'sr-primitives', default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}
-srml-support = { package = 'srml-support', default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}
-srml-support-procedural = { package = 'srml-support-procedural', git = "https://github.com/paritytech/substrate.git", branch = "master"}
-system = { package = 'srml-system', default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}
-balances = { package = 'srml-balances', default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+hex-literal = '0.1.0'
+serde = { version = '1.0', optional = true }
+serde_derive = { version = '1.0', optional = true }
+rstd = { package = 'sr-std', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a2a0eb5398d6223e531455b4c155ef053a4a3a2b'}
+runtime-primitives = { package = 'sr-primitives', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a2a0eb5398d6223e531455b4c155ef053a4a3a2b'}
+srml-support = { package = 'srml-support', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a2a0eb5398d6223e531455b4c155ef053a4a3a2b'}
+srml-support-procedural = { package = 'srml-support-procedural', git = 'https://github.com/paritytech/substrate.git', rev = 'a2a0eb5398d6223e531455b4c155ef053a4a3a2b'}
+system = { package = 'srml-system', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a2a0eb5398d6223e531455b4c155ef053a4a3a2b'}
+balances = { package = 'srml-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a2a0eb5398d6223e531455b4c155ef053a4a3a2b'}
+codec = { package = 'parity-scale-codec', version = '1.0.0', default-features = false, features = ['derive'] }
 
 [dependencies.timestamp]
 default_features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'srml-timestamp'
-branch = "master"
+rev = 'a2a0eb5398d6223e531455b4c155ef053a4a3a2b'
 
 [dependencies.runtime-io]
 default_features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'sr-io'
-branch = "master"
+rev = 'a2a0eb5398d6223e531455b4c155ef053a4a3a2b'
 
 [dev-dependencies]
-runtime-io = { package = 'sr-io', default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}
-primitives = { package = 'substrate-primitives', git = "https://github.com/paritytech/substrate.git", branch = "master"}
+runtime-io = { package = 'sr-io', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a2a0eb5398d6223e531455b4c155ef053a4a3a2b'}
+primitives = { package = 'substrate-primitives', git = 'https://github.com/paritytech/substrate.git', rev = 'a2a0eb5398d6223e531455b4c155ef053a4a3a2b'}
 
 [features]
-default = ["std"]
+default = ['std']
 std = [
-	"serde",
-	"serde_derive",
-	"codec/std",
-	"rstd/std",
-	"runtime-io/std",
-	"runtime-primitives/std",
-	"srml-support/std",
-	"system/std",
-  	"balances/std",
-	"timestamp/std",
+	'serde',
+	'serde_derive',
+	'codec/std',
+	'rstd/std',
+	'runtime-io/std',
+	'runtime-primitives/std',
+	'srml-support/std',
+	'system/std',
+  	'balances/std',
+	'timestamp/std',
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,28 +10,29 @@ serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 parity-codec = { version = "3.2", default-features = false }
 parity-codec-derive = { version = "3.1", default-features = false }
-rstd = { package = 'sr-std', default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "v1.0"}
-runtime-primitives = { package = 'sr-primitives', default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "v1.0"}
-srml-support = { package = 'srml-support', default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "v1.0"}
-srml-support-procedural = { package = 'srml-support-procedural', git = "https://github.com/paritytech/substrate.git", branch = "v1.0"}
-system = { package = 'srml-system', default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "v1.0"}
-balances = { package = 'srml-balances', default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "v1.0"}
+rstd = { package = 'sr-std', default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}
+runtime-primitives = { package = 'sr-primitives', default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}
+srml-support = { package = 'srml-support', default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}
+srml-support-procedural = { package = 'srml-support-procedural', git = "https://github.com/paritytech/substrate.git", branch = "master"}
+system = { package = 'srml-system', default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}
+balances = { package = 'srml-balances', default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}
+codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
 
 [dependencies.timestamp]
 default_features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'srml-timestamp'
-branch = "v1.0"
+branch = "master"
 
 [dependencies.runtime-io]
 default_features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'sr-io'
-branch = "v1.0"
+branch = "master"
 
 [dev-dependencies]
-runtime-io = { package = 'sr-io', default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "v1.0"}
-primitives = { package = 'substrate-primitives', git = "https://github.com/paritytech/substrate.git", branch = "v1.0"}
+runtime-io = { package = 'sr-io', default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}
+primitives = { package = 'substrate-primitives', git = "https://github.com/paritytech/substrate.git", branch = "master"}
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,6 @@ edition = "2018"
 hex-literal = "0.1.0"
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
-parity-codec = { version = "3.2", default-features = false }
-parity-codec-derive = { version = "3.1", default-features = false }
 rstd = { package = 'sr-std', default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}
 runtime-primitives = { package = 'sr-primitives', default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}
 srml-support = { package = 'srml-support', default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}
@@ -39,8 +37,7 @@ default = ["std"]
 std = [
 	"serde",
 	"serde_derive",
-	"parity-codec/std",
-	"parity-codec-derive/std",
+	"codec/std",
 	"rstd/std",
 	"runtime-io/std",
 	"runtime-primitives/std",

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -4,13 +4,13 @@ use crate::*;
 
 use primitives::{Blake2Hasher, H256};
 
-use srml_support::{impl_outer_origin, parameter_types};
 use crate::{GenesisConfig, Module, Trait};
 use runtime_primitives::{
-    Perbill,
-    testing::{Header},
+    testing::Header,
     traits::{BlakeTwo256, IdentityLookup},
+    Perbill,
 };
+use srml_support::{impl_outer_origin, parameter_types};
 
 use runtime_io::with_externalities;
 
@@ -18,12 +18,12 @@ use runtime_io::with_externalities;
 /// mocking behaviour of MembershipRegistry
 pub mod registry {
 
-    use srml_support::*;
     use super::*;
+    use srml_support::*;
 
     #[derive(Encode, Decode, Default, Clone, PartialEq, Eq)]
     pub struct Member<AccountId> {
-        pub id: AccountId
+        pub id: AccountId,
     }
 
     decl_storage! {
@@ -39,27 +39,20 @@ pub mod registry {
     }
 
     impl<T: Trait> Module<T> {
-        pub fn add_member(member: & Member<T::AccountId>) {
+        pub fn add_member(member: &Member<T::AccountId>) {
             <ForumUserById<T>>::insert(member.id.clone(), member.clone());
         }
     }
 
     impl<T: Trait> ForumUserRegistry<T::AccountId> for Module<T> {
-
         fn get_forum_user(id: &T::AccountId) -> Option<ForumUser<T::AccountId>> {
-
             if <ForumUserById<T>>::exists(id) {
-
                 let m = <ForumUserById<T>>::get(id);
 
-                Some(ForumUser{
-                    id : m.id
-                })
-
+                Some(ForumUser { id: m.id })
             } else {
                 None
             }
-
         }
     }
 
@@ -75,30 +68,30 @@ impl_outer_origin! {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Runtime;
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
-	pub const MaximumBlockWeight: u32 = 1024;
-	pub const MaximumBlockLength: u32 = 2 * 1024;
-	pub const AvailableBlockRatio: Perbill = Perbill::one();
+    pub const BlockHashCount: u64 = 250;
+    pub const MaximumBlockWeight: u32 = 1024;
+    pub const MaximumBlockLength: u32 = 2 * 1024;
+    pub const AvailableBlockRatio: Perbill = Perbill::one();
     pub const MinimumPeriod: u64 = 5;
 }
 
 impl system::Trait for Runtime {
-	type Origin = Origin;
-	type Index = u64;
-	type BlockNumber = u64;
-	type Call = ();
-	type Hash = H256;
-	type Hashing = BlakeTwo256;
-	type AccountId = u64;
-	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
-	type WeightMultiplierUpdate = ();
-	type Event = ();
-	type BlockHashCount = BlockHashCount;
-	type MaximumBlockWeight = MaximumBlockWeight;
-	type MaximumBlockLength = MaximumBlockLength;
-	type AvailableBlockRatio = AvailableBlockRatio;
-	type Version = ();
+    type Origin = Origin;
+    type Index = u64;
+    type BlockNumber = u64;
+    type Call = ();
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = u64;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type WeightMultiplierUpdate = ();
+    type Event = ();
+    type BlockHashCount = BlockHashCount;
+    type MaximumBlockWeight = MaximumBlockWeight;
+    type MaximumBlockLength = MaximumBlockLength;
+    type AvailableBlockRatio = AvailableBlockRatio;
+    type Version = ();
 }
 
 impl timestamp::Trait for Runtime {
@@ -116,14 +109,14 @@ impl Trait for Runtime {
 pub enum OriginType {
     Signed(<Runtime as system::Trait>::AccountId),
     //Inherent, <== did not find how to make such an origin yet
-    Root
+    Root,
 }
 
 pub fn mock_origin(origin: OriginType) -> mock::Origin {
     match origin {
         OriginType::Signed(account_id) => Origin::signed(account_id),
         //OriginType::Inherent => Origin::inherent,
-        OriginType::Root => system::RawOrigin::Root.into() //Origin::root
+        OriginType::Root => system::RawOrigin::Root.into(), //Origin::root
     }
 }
 
@@ -175,11 +168,10 @@ pub struct CreateCategoryFixture {
     pub parent: Option<CategoryId>,
     pub title: Vec<u8>,
     pub description: Vec<u8>,
-    pub result: dispatch::Result
+    pub result: dispatch::Result,
 }
 
 impl CreateCategoryFixture {
-
     pub fn call_and_assert(&self) {
         assert_eq!(
             TestForumModule::create_category(
@@ -198,11 +190,10 @@ pub struct UpdateCategoryFixture {
     pub category_id: CategoryId,
     pub new_archival_status: Option<bool>,
     pub new_deletion_status: Option<bool>,
-    pub result: dispatch::Result
+    pub result: dispatch::Result,
 }
 
 impl UpdateCategoryFixture {
-
     pub fn call_and_assert(&self) {
         assert_eq!(
             TestForumModule::update_category(
@@ -221,11 +212,10 @@ pub struct CreateThreadFixture {
     pub category_id: CategoryId,
     pub title: Vec<u8>,
     pub text: Vec<u8>,
-    pub result: dispatch::Result
+    pub result: dispatch::Result,
 }
 
 impl CreateThreadFixture {
-
     pub fn call_and_assert(&self) {
         assert_eq!(
             TestForumModule::create_thread(
@@ -243,11 +233,10 @@ pub struct CreatePostFixture {
     pub origin: OriginType,
     pub thread_id: ThreadId,
     pub text: Vec<u8>,
-    pub result: dispatch::Result
+    pub result: dispatch::Result,
 }
 
 impl CreatePostFixture {
-
     pub fn call_and_assert(&self) {
         assert_eq!(
             TestForumModule::add_post(
@@ -267,41 +256,56 @@ pub fn create_forum_member() -> OriginType {
     OriginType::Signed(member_id)
 }
 
-pub fn assert_create_category(forum_sudo: OriginType, parent_category_id: Option<CategoryId>, expected_result: dispatch::Result) {
+pub fn assert_create_category(
+    forum_sudo: OriginType,
+    parent_category_id: Option<CategoryId>,
+    expected_result: dispatch::Result,
+) {
     CreateCategoryFixture {
         origin: forum_sudo,
         parent: parent_category_id,
         title: good_category_title(),
         description: good_category_description(),
-        result: expected_result
-    }.call_and_assert();
+        result: expected_result,
+    }
+    .call_and_assert();
 }
 
-pub fn assert_create_thread(forum_sudo: OriginType, category_id: CategoryId, expected_result: dispatch::Result) {
+pub fn assert_create_thread(
+    forum_sudo: OriginType,
+    category_id: CategoryId,
+    expected_result: dispatch::Result,
+) {
     CreateThreadFixture {
         origin: forum_sudo,
         category_id,
         title: good_thread_title(),
         text: good_thread_text(),
-        result: expected_result
-    }.call_and_assert();
+        result: expected_result,
+    }
+    .call_and_assert();
 }
 
-pub fn assert_create_post(forum_sudo: OriginType, thread_id: ThreadId, expected_result: dispatch::Result) {
+pub fn assert_create_post(
+    forum_sudo: OriginType,
+    thread_id: ThreadId,
+    expected_result: dispatch::Result,
+) {
     CreatePostFixture {
         origin: forum_sudo,
         thread_id,
         text: good_thread_text(),
-        result: expected_result
-    }.call_and_assert();
+        result: expected_result,
+    }
+    .call_and_assert();
 }
 
-pub fn create_category(forum_sudo: OriginType, parent_category_id: Option<CategoryId>) -> CategoryId {
+pub fn create_category(
+    forum_sudo: OriginType,
+    parent_category_id: Option<CategoryId>,
+) -> CategoryId {
     let category_id = TestForumModule::next_category_id();
-    assert_create_category(
-        forum_sudo, parent_category_id,
-        Ok(())
-    );
+    assert_create_category(forum_sudo, parent_category_id, Ok(()));
     category_id
 }
 
@@ -309,7 +313,9 @@ pub fn create_root_category(forum_sudo: OriginType) -> CategoryId {
     create_category(forum_sudo, None)
 }
 
-pub fn create_root_category_and_thread(forum_sudo: OriginType) -> (OriginType, CategoryId, ThreadId) {
+pub fn create_root_category_and_thread(
+    forum_sudo: OriginType,
+) -> (OriginType, CategoryId, ThreadId) {
     let member_origin = create_forum_member();
     let category_id = create_root_category(forum_sudo);
     let thread_id = TestForumModule::next_thread_id();
@@ -319,14 +325,16 @@ pub fn create_root_category_and_thread(forum_sudo: OriginType) -> (OriginType, C
         category_id,
         title: good_thread_title(),
         text: good_thread_text(),
-        result: Ok(())
+        result: Ok(()),
     }
     .call_and_assert();
 
     (member_origin, category_id, thread_id)
 }
 
-pub fn create_root_category_and_thread_and_post(forum_sudo: OriginType) -> (OriginType, CategoryId, ThreadId, PostId) {
+pub fn create_root_category_and_thread_and_post(
+    forum_sudo: OriginType,
+) -> (OriginType, CategoryId, ThreadId, PostId) {
     let (member_origin, category_id, thread_id) = create_root_category_and_thread(forum_sudo);
     let post_id = TestForumModule::next_post_id();
 
@@ -334,61 +342,48 @@ pub fn create_root_category_and_thread_and_post(forum_sudo: OriginType) -> (Orig
         origin: member_origin.clone(),
         thread_id: thread_id.clone(),
         text: good_post_text(),
-        result: Ok(())
-    }.call_and_assert();
+        result: Ok(()),
+    }
+    .call_and_assert();
 
     (member_origin, category_id, thread_id, post_id)
 }
 
-pub fn moderate_thread(forum_sudo: OriginType, thread_id: ThreadId, rationale: Vec<u8>) -> dispatch::Result {
-    TestForumModule::moderate_thread(
-        mock_origin(forum_sudo), thread_id, rationale
-    )
+pub fn moderate_thread(
+    forum_sudo: OriginType,
+    thread_id: ThreadId,
+    rationale: Vec<u8>,
+) -> dispatch::Result {
+    TestForumModule::moderate_thread(mock_origin(forum_sudo), thread_id, rationale)
 }
 
-pub fn moderate_post(forum_sudo: OriginType, post_id: PostId, rationale: Vec<u8>) -> dispatch::Result {
-    TestForumModule::moderate_post(
-        mock_origin(forum_sudo), post_id, rationale
-    )
+pub fn moderate_post(
+    forum_sudo: OriginType,
+    post_id: PostId,
+    rationale: Vec<u8>,
+) -> dispatch::Result {
+    TestForumModule::moderate_post(mock_origin(forum_sudo), post_id, rationale)
 }
 
 pub fn archive_category(forum_sudo: OriginType, category_id: CategoryId) -> dispatch::Result {
-    TestForumModule::update_category(
-        mock_origin(forum_sudo),
-        category_id,
-        Some(true),
-        None
-    )
+    TestForumModule::update_category(mock_origin(forum_sudo), category_id, Some(true), None)
 }
 
 pub fn unarchive_category(forum_sudo: OriginType, category_id: CategoryId) -> dispatch::Result {
-    TestForumModule::update_category(
-        mock_origin(forum_sudo),
-        category_id,
-        Some(false),
-        None,
-    )
+    TestForumModule::update_category(mock_origin(forum_sudo), category_id, Some(false), None)
 }
 
 pub fn delete_category(forum_sudo: OriginType, category_id: CategoryId) -> dispatch::Result {
-    TestForumModule::update_category(
-        mock_origin(forum_sudo),
-        category_id,
-        None,
-        Some(true),
-    )
+    TestForumModule::update_category(mock_origin(forum_sudo), category_id, None, Some(true))
 }
 
 pub fn undelete_category(forum_sudo: OriginType, category_id: CategoryId) -> dispatch::Result {
-    TestForumModule::update_category(
-        mock_origin(forum_sudo),
-        category_id,
-        None,
-        Some(false),
-    )
+    TestForumModule::update_category(mock_origin(forum_sudo), category_id, None, Some(false))
 }
 
-pub fn assert_not_forum_sudo_cannot_update_category(update_operation: fn (OriginType, CategoryId) -> dispatch::Result) {
+pub fn assert_not_forum_sudo_cannot_update_category(
+    update_operation: fn(OriginType, CategoryId) -> dispatch::Result,
+) {
     let config = default_genesis_config();
     let origin = OriginType::Signed(config.forum_sudo);
 
@@ -409,7 +404,6 @@ pub fn assert_not_forum_sudo_cannot_update_category(update_operation: fn (Origin
 ///
 
 pub fn default_genesis_config() -> GenesisConfig<Runtime> {
-
     GenesisConfig::<Runtime> {
         category_by_id: vec![], // endowed_accounts.iter().cloned().map(|k|(k, 1 << 60)).collect(),
         next_category_id: 1,
@@ -420,49 +414,61 @@ pub fn default_genesis_config() -> GenesisConfig<Runtime> {
 
         forum_sudo: 33,
 
-        category_title_constraint: InputValidationLengthConstraint{
+        category_title_constraint: InputValidationLengthConstraint {
             min: 10,
-            max_min_diff: 140
+            max_min_diff: 140,
         },
 
-        category_description_constraint: InputValidationLengthConstraint{
+        category_description_constraint: InputValidationLengthConstraint {
             min: 10,
-            max_min_diff: 140
+            max_min_diff: 140,
         },
 
-        thread_title_constraint: InputValidationLengthConstraint{
+        thread_title_constraint: InputValidationLengthConstraint {
             min: 3,
-            max_min_diff: 43
+            max_min_diff: 43,
         },
 
-        post_text_constraint: InputValidationLengthConstraint{
+        post_text_constraint: InputValidationLengthConstraint {
             min: 1,
-            max_min_diff: 1001
+            max_min_diff: 1001,
         },
 
-        thread_moderation_rationale_constraint: InputValidationLengthConstraint{
+        thread_moderation_rationale_constraint: InputValidationLengthConstraint {
             min: 10,
-            max_min_diff: 2000
+            max_min_diff: 2000,
         },
 
-        post_moderation_rationale_constraint: InputValidationLengthConstraint{
+        post_moderation_rationale_constraint: InputValidationLengthConstraint {
             min: 10,
-            max_min_diff: 2000
-        }
+            max_min_diff: 2000,
+        }, // JUST GIVING UP ON ALL THIS FOR NOW BECAUSE ITS TAKING TOO LONG
 
-
-        // JUST GIVING UP ON ALL THIS FOR NOW BECAUSE ITS TAKING TOO LONG
-
-        // Extra genesis fields
-        //initial_forum_sudo: Some(143)
+           // Extra genesis fields
+           //initial_forum_sudo: Some(143)
     }
 }
 
-pub type RuntimeMap<K,V> = std::vec::Vec<(K, V)>;
-pub type RuntimeCategory = Category< <Runtime as system::Trait>::BlockNumber, <Runtime as timestamp::Trait>::Moment, <Runtime as system::Trait>::AccountId>;
-pub type RuntimeThread = Thread< <Runtime as system::Trait>::BlockNumber, <Runtime as timestamp::Trait>::Moment, <Runtime as system::Trait>::AccountId>;
-pub type RuntimePost = Post< <Runtime as system::Trait>::BlockNumber, <Runtime as timestamp::Trait>::Moment, <Runtime as system::Trait>::AccountId>;
-pub type RuntimeBlockchainTimestamp = BlockchainTimestamp<<Runtime as system::Trait>::BlockNumber, <Runtime as timestamp::Trait>::Moment>;
+pub type RuntimeMap<K, V> = std::vec::Vec<(K, V)>;
+pub type RuntimeCategory = Category<
+    <Runtime as system::Trait>::BlockNumber,
+    <Runtime as timestamp::Trait>::Moment,
+    <Runtime as system::Trait>::AccountId,
+>;
+pub type RuntimeThread = Thread<
+    <Runtime as system::Trait>::BlockNumber,
+    <Runtime as timestamp::Trait>::Moment,
+    <Runtime as system::Trait>::AccountId,
+>;
+pub type RuntimePost = Post<
+    <Runtime as system::Trait>::BlockNumber,
+    <Runtime as timestamp::Trait>::Moment,
+    <Runtime as system::Trait>::AccountId,
+>;
+pub type RuntimeBlockchainTimestamp = BlockchainTimestamp<
+    <Runtime as system::Trait>::BlockNumber,
+    <Runtime as timestamp::Trait>::Moment,
+>;
 
 pub fn genesis_config(
     category_by_id: &RuntimeMap<CategoryId, RuntimeCategory>,
@@ -477,10 +483,8 @@ pub fn genesis_config(
     thread_title_constraint: &InputValidationLengthConstraint,
     post_text_constraint: &InputValidationLengthConstraint,
     thread_moderation_rationale_constraint: &InputValidationLengthConstraint,
-    post_moderation_rationale_constraint: &InputValidationLengthConstraint
-    )
-    -> GenesisConfig<Runtime> {
-
+    post_moderation_rationale_constraint: &InputValidationLengthConstraint,
+) -> GenesisConfig<Runtime> {
     GenesisConfig::<Runtime> {
         category_by_id: category_by_id.clone(),
         next_category_id: next_category_id,
@@ -494,28 +498,33 @@ pub fn genesis_config(
         thread_title_constraint: thread_title_constraint.clone(),
         post_text_constraint: post_text_constraint.clone(),
         thread_moderation_rationale_constraint: thread_moderation_rationale_constraint.clone(),
-        post_moderation_rationale_constraint: post_moderation_rationale_constraint.clone()
+        post_moderation_rationale_constraint: post_moderation_rationale_constraint.clone(),
     }
 }
 
 // MockForumUserRegistry
 pub fn default_mock_forum_user_registry_genesis_config() -> registry::GenesisConfig<Runtime> {
-
     registry::GenesisConfig::<Runtime> {
-        forum_user_by_id : vec![],
+        forum_user_by_id: vec![],
     }
 }
 
 // NB!:
 // Wanted to have payload: a: &GenesisConfig<Test>
 // but borrow checker made my life miserabl, so giving up for now.
-pub fn build_test_externalities(config: GenesisConfig<Runtime>) -> runtime_io::TestExternalities<Blake2Hasher> {
-    let mut t = system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
+pub fn build_test_externalities(
+    config: GenesisConfig<Runtime>,
+) -> runtime_io::TestExternalities<Blake2Hasher> {
+    let mut t = system::GenesisConfig::default()
+        .build_storage::<Runtime>()
+        .unwrap();
 
     config.assimilate_storage(&mut t).unwrap();
 
     // Add mock registry configuration
-    default_mock_forum_user_registry_genesis_config().assimilate_storage(&mut t).unwrap();
+    default_mock_forum_user_registry_genesis_config()
+        .assimilate_storage(&mut t)
+        .unwrap();
 
     t.into()
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,11 +1,10 @@
-
 #![cfg(test)]
 
 use super::*;
 use crate::mock::*;
 
 use runtime_io::with_externalities;
-use srml_support::{assert_ok, assert_err};
+use srml_support::{assert_err, assert_ok};
 
 /*
 * NB!: No test checks for event emission!!!!
@@ -23,43 +22,49 @@ use srml_support::{assert_ok, assert_err};
 
 #[test]
 fn set_forum_sudo_unset() {
-
     let config = default_genesis_config();
 
     with_externalities(&mut build_test_externalities(config), || {
-
         // Ensure that forum sudo is default
         assert_eq!(TestForumModule::forum_sudo(), Some(33));
 
         // Unset forum sudo
-        assert_ok!(TestForumModule::set_forum_sudo(mock_origin(OriginType::Root), None));
+        assert_ok!(TestForumModule::set_forum_sudo(
+            mock_origin(OriginType::Root),
+            None
+        ));
 
         // Sudo no longer set
         assert!(TestForumModule::forum_sudo().is_none());
 
         // event emitted?!
-
     });
 }
 
 #[test]
 fn set_forum_sudo_update() {
-
     let config = default_genesis_config();
 
     with_externalities(&mut build_test_externalities(config), || {
-
         // Ensure that forum sudo is default
-        assert_eq!(TestForumModule::forum_sudo(), Some(default_genesis_config().forum_sudo));
+        assert_eq!(
+            TestForumModule::forum_sudo(),
+            Some(default_genesis_config().forum_sudo)
+        );
 
         let new_forum_sudo_account_id = 780;
 
         // Unset forum sudo
-        assert_ok!(TestForumModule::set_forum_sudo(mock_origin(OriginType::Root), Some(new_forum_sudo_account_id)));
+        assert_ok!(TestForumModule::set_forum_sudo(
+            mock_origin(OriginType::Root),
+            Some(new_forum_sudo_account_id)
+        ));
 
         // Sudo no longer set
-        assert_eq!(TestForumModule::forum_sudo(), Some(new_forum_sudo_account_id));
-
+        assert_eq!(
+            TestForumModule::forum_sudo(),
+            Some(new_forum_sudo_account_id)
+        );
     });
 }
 
@@ -106,8 +111,9 @@ fn create_category_title_too_short() {
             parent: None,
             title: generate_text(min_len - 1),
             description: good_category_description(),
-            result: Err(ERROR_CATEGORY_TITLE_TOO_SHORT)
-        }.call_and_assert();
+            result: Err(ERROR_CATEGORY_TITLE_TOO_SHORT),
+        }
+        .call_and_assert();
     });
 }
 
@@ -123,8 +129,9 @@ fn create_category_title_too_long() {
             parent: None,
             title: generate_text(max_len + 1),
             description: good_category_description(),
-            result: Err(ERROR_CATEGORY_TITLE_TOO_LONG)
-        }.call_and_assert();
+            result: Err(ERROR_CATEGORY_TITLE_TOO_LONG),
+        }
+        .call_and_assert();
     });
 }
 
@@ -140,8 +147,9 @@ fn create_category_description_too_short() {
             parent: None,
             title: good_category_title(),
             description: generate_text(min_len - 1),
-            result: Err(ERROR_CATEGORY_DESCRIPTION_TOO_SHORT)
-        }.call_and_assert();
+            result: Err(ERROR_CATEGORY_DESCRIPTION_TOO_SHORT),
+        }
+        .call_and_assert();
     });
 }
 
@@ -157,8 +165,9 @@ fn create_category_description_too_long() {
             parent: None,
             title: good_category_title(),
             description: generate_text(max_len + 1),
-            result: Err(ERROR_CATEGORY_DESCRIPTION_TOO_LONG)
-        }.call_and_assert();
+            result: Err(ERROR_CATEGORY_DESCRIPTION_TOO_LONG),
+        }
+        .call_and_assert();
     });
 }
 
@@ -176,7 +185,6 @@ fn create_category_description_too_long() {
 
 #[test]
 fn update_category_undelete_and_unarchive() {
-
     /*
      * Create an initial state with two levels of categories, where
      * leaf category is deleted, and then try to undelete.
@@ -184,82 +192,83 @@ fn update_category_undelete_and_unarchive() {
 
     let forum_sudo = 32;
 
-    let created_at = RuntimeBlockchainTimestamp {
-        block : 0,
-        time: 0
-    };
+    let created_at = RuntimeBlockchainTimestamp { block: 0, time: 0 };
 
-    let category_by_id =  vec![
-
+    let category_by_id = vec![
         // A root category
-        (1, Category{
-            id: 1,
-            title: "New root".as_bytes().to_vec(),
-            description: "This is a new root category".as_bytes().to_vec(),
-            created_at : created_at.clone(),
-            deleted: false,
-            archived: false,
-            num_direct_subcategories: 1,
-            num_direct_unmoderated_threads: 0,
-            num_direct_moderated_threads: 0,
-            position_in_parent_category: None,
-            moderator_id: forum_sudo
-        }),
-
+        (
+            1,
+            Category {
+                id: 1,
+                title: "New root".as_bytes().to_vec(),
+                description: "This is a new root category".as_bytes().to_vec(),
+                created_at: created_at.clone(),
+                deleted: false,
+                archived: false,
+                num_direct_subcategories: 1,
+                num_direct_unmoderated_threads: 0,
+                num_direct_moderated_threads: 0,
+                position_in_parent_category: None,
+                moderator_id: forum_sudo,
+            },
+        ),
         // A subcategory of the one above
-        (2, Category{
-            id: 2,
-            title: "New subcategory".as_bytes().to_vec(),
-            description: "This is a new subcategory to root category".as_bytes().to_vec(),
-            created_at : created_at.clone(),
-            deleted: true,
-            archived: false,
-            num_direct_subcategories: 0,
-            num_direct_unmoderated_threads: 0,
-            num_direct_moderated_threads: 0,
-            position_in_parent_category: Some(
-                ChildPositionInParentCategory {
+        (
+            2,
+            Category {
+                id: 2,
+                title: "New subcategory".as_bytes().to_vec(),
+                description: "This is a new subcategory to root category"
+                    .as_bytes()
+                    .to_vec(),
+                created_at: created_at.clone(),
+                deleted: true,
+                archived: false,
+                num_direct_subcategories: 0,
+                num_direct_unmoderated_threads: 0,
+                num_direct_moderated_threads: 0,
+                position_in_parent_category: Some(ChildPositionInParentCategory {
                     parent_id: 1,
-                    child_nr_in_parent_category: 1
-                }
-            ),
-            moderator_id: forum_sudo
-        }),
+                    child_nr_in_parent_category: 1,
+                }),
+                moderator_id: forum_sudo,
+            },
+        ),
     ];
 
     // Set constraints to be sloppy, we don't care about enforcing them.
-    let sloppy_constraint = InputValidationLengthConstraint{
+    let sloppy_constraint = InputValidationLengthConstraint {
         min: 0,
-        max_min_diff: 1000
+        max_min_diff: 1000,
     };
 
     let config = genesis_config(
-        &category_by_id, // category_by_id
+        &category_by_id,             // category_by_id
         category_by_id.len() as u64, // next_category_id
-        &vec![], // thread_by_id
-        1, // next_thread_id
-        &vec![], // post_by_id
-        1, // next_post_id
+        &vec![],                     // thread_by_id
+        1,                           // next_thread_id
+        &vec![],                     // post_by_id
+        1,                           // next_post_id
         forum_sudo,
         &sloppy_constraint,
         &sloppy_constraint,
         &sloppy_constraint,
         &sloppy_constraint,
         &sloppy_constraint,
-        &sloppy_constraint
+        &sloppy_constraint,
     );
 
     with_externalities(&mut build_test_externalities(config), || {
         UpdateCategoryFixture {
             origin: OriginType::Signed(forum_sudo),
             category_id: 2,
-            new_archival_status: None, // same as before
+            new_archival_status: None,        // same as before
             new_deletion_status: Some(false), // undelete
-            result: Ok(())
-        }.call_and_assert();
+            result: Ok(()),
+        }
+        .call_and_assert();
     });
 }
-
 
 /*
  * create_thread
@@ -286,8 +295,9 @@ fn create_thread_successfully() {
             category_id,
             title: good_thread_title(),
             text: good_thread_text(),
-            result: Ok(())
-        }.call_and_assert();
+            result: Ok(()),
+        }
+        .call_and_assert();
     });
 }
 
@@ -306,8 +316,9 @@ fn create_thread_title_too_short() {
             category_id,
             title: generate_text(min_len - 1),
             text: good_thread_text(),
-            result: Err(ERROR_THREAD_TITLE_TOO_SHORT)
-        }.call_and_assert();
+            result: Err(ERROR_THREAD_TITLE_TOO_SHORT),
+        }
+        .call_and_assert();
     });
 }
 
@@ -326,8 +337,9 @@ fn create_thread_title_too_long() {
             category_id,
             title: generate_text(max_len + 1),
             text: good_thread_text(),
-            result: Err(ERROR_THREAD_TITLE_TOO_LONG)
-        }.call_and_assert();
+            result: Err(ERROR_THREAD_TITLE_TOO_LONG),
+        }
+        .call_and_assert();
     });
 }
 
@@ -346,8 +358,9 @@ fn create_thread_text_too_short() {
             category_id,
             title: good_thread_title(),
             text: generate_text(min_len - 1),
-            result: Err(ERROR_POST_TEXT_TOO_SHORT)
-        }.call_and_assert();
+            result: Err(ERROR_POST_TEXT_TOO_SHORT),
+        }
+        .call_and_assert();
     });
 }
 
@@ -366,8 +379,9 @@ fn create_thread_text_too_long() {
             category_id,
             title: good_thread_title(),
             text: generate_text(max_len + 1),
-            result: Err(ERROR_POST_TEXT_TOO_LONG)
-        }.call_and_assert();
+            result: Err(ERROR_POST_TEXT_TOO_LONG),
+        }
+        .call_and_assert();
     });
 }
 
@@ -394,8 +408,9 @@ fn create_post_text_too_short() {
             origin: member_origin,
             thread_id,
             text: generate_text(min_len - 1),
-            result: Err(ERROR_POST_TEXT_TOO_SHORT)
-        }.call_and_assert();
+            result: Err(ERROR_POST_TEXT_TOO_SHORT),
+        }
+        .call_and_assert();
     });
 }
 
@@ -412,8 +427,9 @@ fn create_post_text_too_long() {
             origin: member_origin,
             thread_id,
             text: generate_text(max_len + 1),
-            result: Err(ERROR_POST_TEXT_TOO_LONG)
-        }.call_and_assert();
+            result: Err(ERROR_POST_TEXT_TOO_LONG),
+        }
+        .call_and_assert();
     });
 }
 
@@ -551,8 +567,9 @@ fn not_forum_sudo_cannot_create_root_category() {
 
     with_externalities(&mut build_test_externalities(config), || {
         assert_create_category(
-            NOT_FORUM_SUDO_ORIGIN, None,
-            Err(ERROR_ORIGIN_NOT_FORUM_SUDO)
+            NOT_FORUM_SUDO_ORIGIN,
+            None,
+            Err(ERROR_ORIGIN_NOT_FORUM_SUDO),
         );
     });
 }
@@ -565,38 +582,31 @@ fn not_forum_sudo_cannot_create_subcategory() {
     with_externalities(&mut build_test_externalities(config), || {
         let root_category_id = create_root_category(origin);
         assert_create_category(
-            NOT_FORUM_SUDO_ORIGIN, Some(root_category_id),
-            Err(ERROR_ORIGIN_NOT_FORUM_SUDO)
+            NOT_FORUM_SUDO_ORIGIN,
+            Some(root_category_id),
+            Err(ERROR_ORIGIN_NOT_FORUM_SUDO),
         );
     });
 }
 
 #[test]
 fn not_forum_sudo_cannot_archive_category() {
-    assert_not_forum_sudo_cannot_update_category(
-        archive_category
-    );
+    assert_not_forum_sudo_cannot_update_category(archive_category);
 }
 
 #[test]
 fn not_forum_sudo_cannot_unarchive_category() {
-    assert_not_forum_sudo_cannot_update_category(
-        unarchive_category
-    );
+    assert_not_forum_sudo_cannot_update_category(unarchive_category);
 }
 
 #[test]
 fn not_forum_sudo_cannot_delete_category() {
-    assert_not_forum_sudo_cannot_update_category(
-        delete_category
-    );
+    assert_not_forum_sudo_cannot_update_category(delete_category);
 }
 
 #[test]
 fn not_forum_sudo_cannot_undelete_category() {
-    assert_not_forum_sudo_cannot_update_category(
-        undelete_category
-    );
+    assert_not_forum_sudo_cannot_update_category(undelete_category);
 }
 
 #[test]
@@ -641,8 +651,9 @@ fn not_member_cannot_create_thread() {
             category_id: create_root_category(origin),
             title: good_thread_title(),
             text: good_thread_text(),
-            result: Err(ERROR_NOT_FORUM_USER)
-        }.call_and_assert();
+            result: Err(ERROR_NOT_FORUM_USER),
+        }
+        .call_and_assert();
     });
 }
 
@@ -657,8 +668,9 @@ fn not_member_cannot_create_post() {
             origin: NOT_MEMBER_ORIGIN,
             thread_id,
             text: good_post_text(),
-            result: Err(ERROR_NOT_FORUM_USER)
-        }.call_and_assert();
+            result: Err(ERROR_NOT_FORUM_USER),
+        }
+        .call_and_assert();
     });
 }
 
@@ -690,8 +702,9 @@ fn cannot_create_subcategory_with_invalid_parent_category_id() {
 
     with_externalities(&mut build_test_externalities(config), || {
         assert_create_category(
-            origin, Some(INVLAID_CATEGORY_ID),
-            Err(ERROR_CATEGORY_DOES_NOT_EXIST)
+            origin,
+            Some(INVLAID_CATEGORY_ID),
+            Err(ERROR_CATEGORY_DOES_NOT_EXIST),
         );
     });
 }
@@ -706,8 +719,9 @@ fn cannot_create_thread_with_invalid_category_id() {
             category_id: INVLAID_CATEGORY_ID,
             title: good_thread_title(),
             text: good_thread_text(),
-            result: Err(ERROR_CATEGORY_DOES_NOT_EXIST)
-        }.call_and_assert();
+            result: Err(ERROR_CATEGORY_DOES_NOT_EXIST),
+        }
+        .call_and_assert();
     });
 }
 
@@ -720,8 +734,9 @@ fn cannot_create_post_with_invalid_thread_id() {
             origin: create_forum_member(),
             thread_id: INVLAID_THREAD_ID,
             text: good_post_text(),
-            result: Err(ERROR_THREAD_DOES_NOT_EXIST)
-        }.call_and_assert();
+            result: Err(ERROR_THREAD_DOES_NOT_EXIST),
+        }
+        .call_and_assert();
     });
 }
 
@@ -761,20 +776,10 @@ fn archive_then_unarchive_category_successfully() {
 
     with_externalities(&mut build_test_externalities(config), || {
         let category_id = create_root_category(forum_sudo.clone());
-        assert_ok!(
-            archive_category(
-                forum_sudo.clone(),
-                category_id.clone(),
-            )
-        );
+        assert_ok!(archive_category(forum_sudo.clone(), category_id.clone(),));
         // TODO get category by id and assert archived == true.
 
-        assert_ok!(
-            unarchive_category(
-                forum_sudo,
-                category_id,
-            )
-        );
+        assert_ok!(unarchive_category(forum_sudo, category_id,));
         // TODO get category by id and assert archived == false.
     });
 }
@@ -786,20 +791,10 @@ fn delete_then_undelete_category_successfully() {
 
     with_externalities(&mut build_test_externalities(config), || {
         let category_id = create_root_category(forum_sudo.clone());
-        assert_ok!(
-            delete_category(
-                forum_sudo.clone(),
-                category_id.clone(),
-            )
-        );
+        assert_ok!(delete_category(forum_sudo.clone(), category_id.clone(),));
         // TODO get category by id and assert deleted == true.
 
-        assert_ok!(
-            undelete_category(
-                forum_sudo.clone(),
-                category_id.clone(),
-            )
-        );
+        assert_ok!(undelete_category(forum_sudo.clone(), category_id.clone(),));
         // TODO get category by id and assert deleted == false.
     });
 }
@@ -853,15 +848,11 @@ fn cannot_create_subcategory_in_archived_category() {
 
     with_externalities(&mut build_test_externalities(config), || {
         let category_id = create_root_category(forum_sudo.clone());
-        assert_ok!(
-            archive_category(
-                forum_sudo.clone(),
-                category_id.clone(),
-            )
-        );
+        assert_ok!(archive_category(forum_sudo.clone(), category_id.clone(),));
         assert_create_category(
-            forum_sudo, Some(category_id),
-            Err(ERROR_ANCESTOR_CATEGORY_IMMUTABLE)
+            forum_sudo,
+            Some(category_id),
+            Err(ERROR_ANCESTOR_CATEGORY_IMMUTABLE),
         );
     });
 }
@@ -873,15 +864,11 @@ fn cannot_create_subcategory_in_deleted_category() {
 
     with_externalities(&mut build_test_externalities(config), || {
         let category_id = create_root_category(forum_sudo.clone());
-        assert_ok!(
-            delete_category(
-                forum_sudo.clone(),
-                category_id.clone(),
-            )
-        );
+        assert_ok!(delete_category(forum_sudo.clone(), category_id.clone(),));
         assert_create_category(
-            forum_sudo, Some(category_id),
-            Err(ERROR_ANCESTOR_CATEGORY_IMMUTABLE)
+            forum_sudo,
+            Some(category_id),
+            Err(ERROR_ANCESTOR_CATEGORY_IMMUTABLE),
         );
     });
 }
@@ -893,15 +880,11 @@ fn cannot_create_thread_in_archived_category() {
 
     with_externalities(&mut build_test_externalities(config), || {
         let category_id = create_root_category(forum_sudo.clone());
-        assert_ok!(
-            archive_category(
-                forum_sudo.clone(),
-                category_id.clone(),
-            )
-        );
+        assert_ok!(archive_category(forum_sudo.clone(), category_id.clone(),));
         assert_create_thread(
-            create_forum_member(), category_id,
-            Err(ERROR_ANCESTOR_CATEGORY_IMMUTABLE)
+            create_forum_member(),
+            category_id,
+            Err(ERROR_ANCESTOR_CATEGORY_IMMUTABLE),
         );
     });
 }
@@ -913,15 +896,11 @@ fn cannot_create_thread_in_deleted_category() {
 
     with_externalities(&mut build_test_externalities(config), || {
         let category_id = create_root_category(forum_sudo.clone());
-        assert_ok!(
-            delete_category(
-                forum_sudo.clone(),
-                category_id.clone(),
-            )
-        );
+        assert_ok!(delete_category(forum_sudo.clone(), category_id.clone(),));
         assert_create_thread(
-            create_forum_member(), category_id,
-            Err(ERROR_ANCESTOR_CATEGORY_IMMUTABLE)
+            create_forum_member(),
+            category_id,
+            Err(ERROR_ANCESTOR_CATEGORY_IMMUTABLE),
         );
     });
 }
@@ -934,19 +913,12 @@ fn cannot_create_post_in_thread_of_archived_category() {
     with_externalities(&mut build_test_externalities(config), || {
         let category_id = create_root_category(forum_sudo.clone());
         let thread_id = TestForumModule::next_thread_id();
-        assert_create_thread(
-            create_forum_member(), category_id,
-            Ok(())
-        );
-        assert_ok!(
-            archive_category(
-                forum_sudo.clone(),
-                category_id.clone(),
-            )
-        );
+        assert_create_thread(create_forum_member(), category_id, Ok(()));
+        assert_ok!(archive_category(forum_sudo.clone(), category_id.clone(),));
         assert_create_post(
-            create_forum_member(), thread_id,
-            Err(ERROR_ANCESTOR_CATEGORY_IMMUTABLE)
+            create_forum_member(),
+            thread_id,
+            Err(ERROR_ANCESTOR_CATEGORY_IMMUTABLE),
         );
     });
 }
@@ -959,19 +931,12 @@ fn cannot_create_post_in_thread_of_deleted_category() {
     with_externalities(&mut build_test_externalities(config), || {
         let category_id = create_root_category(forum_sudo.clone());
         let thread_id = TestForumModule::next_thread_id();
-        assert_create_thread(
-            create_forum_member(), category_id,
-            Ok(())
-        );
-        assert_ok!(
-            delete_category(
-                forum_sudo.clone(),
-                category_id.clone(),
-            )
-        );
+        assert_create_thread(create_forum_member(), category_id, Ok(()));
+        assert_ok!(delete_category(forum_sudo.clone(), category_id.clone(),));
         assert_create_post(
-            create_forum_member(), thread_id,
-            Err(ERROR_ANCESTOR_CATEGORY_IMMUTABLE)
+            create_forum_member(),
+            thread_id,
+            Err(ERROR_ANCESTOR_CATEGORY_IMMUTABLE),
         );
     });
 }
@@ -983,12 +948,15 @@ fn cannot_create_post_in_moderated_thread() {
 
     with_externalities(&mut build_test_externalities(config), || {
         let (_, _, thread_id) = create_root_category_and_thread(forum_sudo.clone());
-        assert_ok!(
-            moderate_thread(forum_sudo, thread_id.clone(), good_rationale())
-        );
+        assert_ok!(moderate_thread(
+            forum_sudo,
+            thread_id.clone(),
+            good_rationale()
+        ));
         assert_create_post(
-            create_forum_member(), thread_id,
-            Err(ERROR_THREAD_MODERATED)
+            create_forum_member(),
+            thread_id,
+            Err(ERROR_THREAD_MODERATED),
         );
     });
 }
@@ -999,16 +967,11 @@ fn cannot_edit_post_in_moderated_thread() {
     let forum_sudo = OriginType::Signed(config.forum_sudo);
 
     with_externalities(&mut build_test_externalities(config), || {
-        let (member_origin, _, thread_id, post_id) = create_root_category_and_thread_and_post(forum_sudo.clone());
-        assert_ok!(
-            moderate_thread(forum_sudo, thread_id, good_rationale())
-        );
+        let (member_origin, _, thread_id, post_id) =
+            create_root_category_and_thread_and_post(forum_sudo.clone());
+        assert_ok!(moderate_thread(forum_sudo, thread_id, good_rationale()));
         assert_err!(
-            TestForumModule::edit_post_text(
-                mock_origin(member_origin),
-                post_id,
-                good_rationale()
-            ),
+            TestForumModule::edit_post_text(mock_origin(member_origin), post_id, good_rationale()),
             ERROR_THREAD_MODERATED
         );
     });

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -6,7 +6,7 @@ use crate::mock::*;
 
 use runtime_io::with_externalities;
 use srml_support::{assert_ok, assert_err};
-use system::RawOrigin;
+
 /*
 * NB!: No test checks for event emission!!!!
 */
@@ -32,7 +32,7 @@ fn set_forum_sudo_unset() {
         assert_eq!(TestForumModule::forum_sudo(), Some(33));
 
         // Unset forum sudo
-        assert_ok!(TestForumModule::set_forum_sudo(RawOrigin::Root.into(), None));
+        assert_ok!(TestForumModule::set_forum_sudo(mock_origin(OriginType::Root), None));
 
         // Sudo no longer set
         assert!(TestForumModule::forum_sudo().is_none());
@@ -55,7 +55,7 @@ fn set_forum_sudo_update() {
         let new_forum_sudo_account_id = 780;
 
         // Unset forum sudo
-        assert_ok!(TestForumModule::set_forum_sudo(RawOrigin::Root.into(), Some(new_forum_sudo_account_id)));
+        assert_ok!(TestForumModule::set_forum_sudo(mock_origin(OriginType::Root), Some(new_forum_sudo_account_id)));
 
         // Sudo no longer set
         assert_eq!(TestForumModule::forum_sudo(), Some(new_forum_sudo_account_id));

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -6,8 +6,7 @@ use crate::mock::*;
 
 use runtime_io::with_externalities;
 use srml_support::{assert_ok, assert_err};
-
-
+use system::RawOrigin;
 /*
 * NB!: No test checks for event emission!!!!
 */
@@ -33,7 +32,7 @@ fn set_forum_sudo_unset() {
         assert_eq!(TestForumModule::forum_sudo(), Some(33));
 
         // Unset forum sudo
-        assert_ok!(TestForumModule::set_forum_sudo(None));
+        assert_ok!(TestForumModule::set_forum_sudo(RawOrigin::Root.into(), None));
 
         // Sudo no longer set
         assert!(TestForumModule::forum_sudo().is_none());
@@ -56,7 +55,7 @@ fn set_forum_sudo_update() {
         let new_forum_sudo_account_id = 780;
 
         // Unset forum sudo
-        assert_ok!(TestForumModule::set_forum_sudo(Some(new_forum_sudo_account_id)));
+        assert_ok!(TestForumModule::set_forum_sudo(RawOrigin::Root.into(), Some(new_forum_sudo_account_id)));
 
         // Sudo no longer set
         assert_eq!(TestForumModule::forum_sudo(), Some(new_forum_sudo_account_id));
@@ -608,7 +607,7 @@ fn not_forum_sudo_cannot_moderate_thread() {
     with_externalities(&mut build_test_externalities(config), || {
         let (_, _, thread_id) = create_root_category_and_thread(origin.clone());
         assert_eq!(
-            moderate_thread(NOT_FORUM_SUDO_ORIGIN, thread_id, good_rationale()), 
+            moderate_thread(NOT_FORUM_SUDO_ORIGIN, thread_id, good_rationale()),
             Err(ERROR_ORIGIN_NOT_FORUM_SUDO)
         );
     });
@@ -622,7 +621,7 @@ fn not_forum_sudo_cannot_moderate_post() {
     with_externalities(&mut build_test_externalities(config), || {
         let (_, _, _, post_id) = create_root_category_and_thread_and_post(origin.clone());
         assert_eq!(
-            moderate_post(NOT_FORUM_SUDO_ORIGIN, post_id, good_rationale()), 
+            moderate_post(NOT_FORUM_SUDO_ORIGIN, post_id, good_rationale()),
             Err(ERROR_ORIGIN_NOT_FORUM_SUDO)
         );
     });


### PR DESCRIPTION
Experiment to see how involved it will be to migrate our runtime code to use substrate latest master branch (substrate v2). It is not not all that terrible, at least for the forum module.

Notable changes needed:

- All methods in decl_module! now must explicitly have origin argument, and use ensure_root! for privileged method (decl_module macro doesn't automagically do it for us anymore)
- new dependency on `parity-scale-codec` crate in place of the `parity_codec_derive` crate
- Previously when using a storage value like so `<NextCategoryId<T>>::get();` even when the type didn't actually use any type from `T` was ok. Now it results in a compiler error to the affect that `T` is not required. So `NextCategory::get()` is all that is required.
- Some minor changes needing to setup mocked Runtime and srml modules
- Composing GenesisConfig for tests is a little different. 

Will try similar exercise on the main runtime repo.